### PR TITLE
feat: replace topbar user text with avatar icon dropdown

### DIFF
--- a/src/components/layout/Topbar.jsx
+++ b/src/components/layout/Topbar.jsx
@@ -1,8 +1,25 @@
 import React, { Component } from "react";
 
 class Topbar extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { dropdownOpen: false };
+        this.avatarRef = React.createRef();
+    }
+
+    handleMouseEnter = () => {
+        this.setState({ dropdownOpen: true });
+    };
+
+    handleMouseLeave = () => {
+        this.setState({ dropdownOpen: false });
+    };
+
     render() {
         const { username, onLogout } = this.props;
+        const { dropdownOpen } = this.state;
+
+        const initial = username ? username.charAt(0).toUpperCase() : "U";
 
         const topbarStyle = {
             height: 56,
@@ -16,22 +33,60 @@ class Topbar extends Component {
             zIndex: 100,
         };
 
-        const rightStyle = {
+        const avatarStyle = {
+            width: 36,
+            height: 36,
+            borderRadius: "50%",
+            background: "#1677ff",
+            color: "#fff",
             display: "flex",
             alignItems: "center",
-            gap: 16,
-            fontSize: 14,
-            color: "#555",
+            justifyContent: "center",
+            fontWeight: 700,
+            fontSize: 15,
+            cursor: "pointer",
+            userSelect: "none",
+            flexShrink: 0,
         };
 
-        const logoutBtnStyle = {
-            padding: "6px 14px",
-            borderRadius: 4,
-            border: "1px solid #ff4d4f",
-            background: "transparent",
+        const dropdownStyle = {
+            position: "absolute",
+            top: 48,
+            right: 0,
+            background: "#fff",
+            borderRadius: 8,
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            minWidth: 180,
+            zIndex: 999,
+            overflow: "hidden",
+            border: "1px solid #f0f0f0",
+        };
+
+        const dropdownHeaderStyle = {
+            padding: "12px 16px",
+            borderBottom: "1px solid #f0f0f0",
+            fontSize: 13,
+            color: "#888",
+        };
+
+        const dropdownUsernameStyle = {
+            fontWeight: 600,
+            color: "#333",
+            fontSize: 14,
+        };
+
+        const logoutItemStyle = {
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "10px 16px",
+            fontSize: 14,
             color: "#ff4d4f",
             cursor: "pointer",
-            fontSize: 13,
+            background: "transparent",
+            border: "none",
+            width: "100%",
+            textAlign: "left",
         };
 
         return (
@@ -39,11 +94,33 @@ class Topbar extends Component {
                 <span style={{ fontSize: 15, fontWeight: 600, color: "#1a1a2e" }}>
                     DevAPIHub Admin
                 </span>
-                <div style={rightStyle}>
-                    <span>Xin chào, <strong>{username}</strong></span>
-                    <button style={logoutBtnStyle} onClick={onLogout}>
-                        Đăng xuất
-                    </button>
+
+                {/* Avatar + dropdown */}
+                <div
+                    style={{ position: "relative" }}
+                    onMouseEnter={this.handleMouseEnter}
+                    onMouseLeave={this.handleMouseLeave}
+                    ref={this.avatarRef}
+                >
+                    <div style={avatarStyle}>{initial}</div>
+
+                    {dropdownOpen && (
+                        <div style={dropdownStyle}>
+                            <div style={dropdownHeaderStyle}>
+                                <div style={{ fontSize: 12, marginBottom: 2 }}>Đang đăng nhập</div>
+                                <div style={dropdownUsernameStyle}>{username}</div>
+                            </div>
+                            <button
+                                style={logoutItemStyle}
+                                onClick={onLogout}
+                                onMouseEnter={(e) => (e.currentTarget.style.background = "#fff2f0")}
+                                onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+                            >
+                                <span>⎋</span>
+                                <span>Đăng xuất</span>
+                            </button>
+                        </div>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
## Mô tả

Thay thế phần hiển thị `Xin chào, admin` + nút `Đăng xuất` riêng lẻ ở góc phải header bằng **avatar icon** (hình tròn chứa chữ cái đầu username).

## Thay đổi

- Avatar hình tròn màu xanh, hiển thị chữ cái đầu của `username`
- Hover vào avatar → dropdown xuất hiện gồm:
  - Tên đăng nhập (header)
  - Nút **Đăng xuất**
- Hover vào nút Đăng xuất → highlight đỏ nhạt

## File đã sửa

- `src/components/layout/Topbar.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)