### PR TITLE
fix: prevent dropdown from closing when moving mouse to options

### DIFF
--- a/src/components/layout/Topbar.jsx
+++ b/src/components/layout/Topbar.jsx
@@ -8,11 +8,14 @@ class Topbar extends Component {
     }
 
     handleMouseEnter = () => {
+        if (this.leaveTimeout) clearTimeout(this.leaveTimeout);
         this.setState({ dropdownOpen: true });
     };
 
     handleMouseLeave = () => {
-        this.setState({ dropdownOpen: false });
+        this.leaveTimeout = setTimeout(() => {
+            this.setState({ dropdownOpen: false });
+        }, 150);
     };
 
     render() {


### PR DESCRIPTION
## Summary

Fixes #4

The topbar avatar dropdown was closing before the user could select any option.

## Root Cause

The wrapper `div` height equals the avatar (36px), but the dropdown was positioned at `top: 48px` — creating a 12px invisible gap. Moving the mouse through that gap fired `onMouseLeave` on the wrapper, closing the dropdown immediately.

## Fix

Added a 150ms delay on `handleMouseLeave` and cancel it on `handleMouseEnter`. This gives the mouse time to travel from the avatar into the dropdown without triggering a close.

```js
handleMouseLeave = () => {
    this.leaveTimeout = setTimeout(() => {
        this.setState({ dropdownOpen: false });
    }, 150);
};
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)