### PR TITLE
feat: add Kubernetes deployment and service manifests

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admin-ui
+  labels:
+    app: admin-ui
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: admin-ui
+  template:
+    metadata:
+      labels:
+        app: admin-ui
+    spec:
+      containers:
+        - name: admin-ui
+          image: trivip002/admin-ui:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admin-ui
+  labels:
+    app: admin-ui
+spec:
+  type: LoadBalancer
+  selector:
+    app: admin-ui
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary

Closes #8

Add Kubernetes manifests under `k8s/` to deploy the admin UI to a cluster.

## Files

### `k8s/deployment.yaml`
- Image: `trivip002/admin-ui:latest`
- 2 replicas
- Resource limits: 200m CPU / 128Mi RAM
- Liveness & readiness probes on `GET /`

### `k8s/service.yaml`
- Type: `LoadBalancer` — exposes app externally on port 80
- Change to `ClusterIP` if using an Ingress controller instead

## How to deploy

```bash
kubectl apply -f k8s/

# Check status
kubectl get pods -l app=admin-ui
kubectl get svc admin-ui
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)