### PR TITLE
fix: apply theme to ToolsPage components

### DIFF
--- a/src/pages/ToolsPage/ToolDeleteDialog.jsx
+++ b/src/pages/ToolsPage/ToolDeleteDialog.jsx
@@ -1,69 +1,43 @@
 import React, { Component } from "react";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
 
 class ToolDeleteDialog extends Component {
+    static contextType = ThemeContext;
+
     render() {
         const { open, onConfirm, onCancel } = this.props;
+        const { theme } = this.context;
 
         if (!open) return null;
-
-        const backdropStyle = {
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.45)",
-            zIndex: 1000,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-        };
-
-        const cardStyle = {
-            background: "#fff",
-            borderRadius: 8,
-            padding: "28px 32px",
-            width: 400,
-            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
-        };
-
-        const footerStyle = {
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 10,
-            marginTop: 24,
-        };
 
         const cancelBtnStyle = {
             padding: "8px 20px",
             borderRadius: 4,
-            border: "1px solid #d9d9d9",
-            background: "#fff",
-            cursor: "pointer",
-            fontSize: 14,
-        };
-
-        const deleteBtnStyle = {
-            padding: "8px 20px",
-            borderRadius: 4,
-            border: "none",
-            background: "#ff4d4f",
-            color: "#fff",
+            border: `1px solid ${theme.dropdown.border}`,
+            background: "transparent",
+            color: theme.dropdown.text,
             cursor: "pointer",
             fontSize: 14,
         };
 
         return (
-            <div style={backdropStyle} onClick={onCancel}>
-                <div style={cardStyle} onClick={(e) => e.stopPropagation()}>
-                    <h3 style={{ marginTop: 0, fontSize: 16, color: "#333" }}>Xác nhận xoá</h3>
-                    <p style={{ color: "#555", fontSize: 14, lineHeight: 1.6 }}>
+            <div
+                style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.55)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}
+                onClick={onCancel}
+            >
+                <div
+                    style={{ background: theme.dropdown.bg, borderRadius: 8, padding: "28px 32px", width: 400, boxShadow: "0 4px 24px rgba(0,0,0,0.3)", border: `1px solid ${theme.dropdown.border}` }}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <h3 style={{ marginTop: 0, fontSize: 16, color: theme.dropdown.text }}>Xác nhận xoá</h3>
+                    <p style={{ color: theme.dropdown.textSub, fontSize: 14, lineHeight: 1.6 }}>
                         Bạn có chắc muốn xoá sản phẩm này không?
                         <br />
-                        <span style={{ color: "#ff4d4f", fontSize: 13 }}>
-                            Hành động này không thể hoàn tác.
-                        </span>
+                        <span style={{ color: "#ff4d4f", fontSize: 13 }}>Hành động này không thể hoàn tác.</span>
                     </p>
-                    <div style={footerStyle}>
+                    <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, marginTop: 24 }}>
                         <button style={cancelBtnStyle} onClick={onCancel}>Huỷ</button>
-                        <button style={deleteBtnStyle} onClick={onConfirm}>Xoá</button>
+                        <button style={{ padding: "8px 20px", borderRadius: 4, border: "none", background: "#ff4d4f", color: "#fff", cursor: "pointer", fontSize: 14 }} onClick={onConfirm}>Xoá</button>
                     </div>
                 </div>
             </div>

--- a/src/pages/ToolsPage/ToolFormModal.jsx
+++ b/src/pages/ToolsPage/ToolFormModal.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { CATEGORIES } from "../../data/mockTools.js";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
 
 const EMPTY_FORM = {
     name: "",
@@ -11,6 +12,8 @@ const EMPTY_FORM = {
 };
 
 class ToolFormModal extends Component {
+    static contextType = ThemeContext;
+
     constructor(props) {
         super(props);
         this.state = { ...EMPTY_FORM, errors: {} };
@@ -47,53 +50,34 @@ class ToolFormModal extends Component {
         const errors = {};
 
         if (!name.trim()) errors.name = "Vui lòng nhập tên sản phẩm";
-        if (!price || isNaN(Number(price)) || Number(price) < 0)
-            errors.price = "Giá không hợp lệ";
-        if (!stock || isNaN(Number(stock)) || Number(stock) < 0)
-            errors.stock = "Tồn kho không hợp lệ";
+        if (!price || isNaN(Number(price)) || Number(price) < 0) errors.price = "Giá không hợp lệ";
+        if (!stock || isNaN(Number(stock)) || Number(stock) < 0) errors.stock = "Tồn kho không hợp lệ";
 
         if (Object.keys(errors).length > 0) {
             this.setState({ errors });
             return;
         }
 
-        this.props.onSubmit({
-            name: name.trim(),
-            category,
-            price: Number(price),
-            stock: Number(stock),
-            description,
-            active,
-        });
+        this.props.onSubmit({ name: name.trim(), category, price: Number(price), stock: Number(stock), description, active });
     };
 
     render() {
         const { open, mode, onClose } = this.props;
         const { name, category, price, stock, description, active, errors } = this.state;
+        const { theme } = this.context;
 
         if (!open) return null;
 
         const isEdit = mode === "edit";
-        const title = isEdit ? "Chỉnh sửa sản phẩm" : "Thêm sản phẩm mới";
-
-        const backdropStyle = {
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.45)",
-            zIndex: 1000,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-        };
 
         const cardStyle = {
-            background: "#fff",
+            background: theme.dropdown.bg,
             borderRadius: 8,
             padding: "28px 32px",
             minWidth: 480,
             maxWidth: 580,
             width: "100%",
-            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.3)",
             maxHeight: "90vh",
             overflowY: "auto",
         };
@@ -103,137 +87,102 @@ class ToolFormModal extends Component {
             marginBottom: 6,
             fontWeight: 500,
             fontSize: 13,
-            color: "#333",
+            color: theme.dropdown.text,
         };
 
         const inputStyle = {
             width: "100%",
             padding: "8px 12px",
-            border: "1px solid #d9d9d9",
+            border: `1px solid ${theme.dropdown.border}`,
             borderRadius: 4,
             fontSize: 14,
             boxSizing: "border-box",
             outline: "none",
-            background: "#fff",
-        };
-
-        const errorStyle = { color: "#ff4d4f", fontSize: 12, marginTop: 4 };
-        const fieldStyle = { marginBottom: 16 };
-
-        const rowStyle = { display: "flex", gap: 16 };
-        const halfStyle = { flex: 1 };
-
-        const footerStyle = {
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 10,
-            marginTop: 24,
-            paddingTop: 16,
-            borderTop: "1px solid #f0f0f0",
+            background: theme.toggleIcon === "🌙" ? "rgba(255,255,255,0.06)" : "#fff",
+            color: theme.dropdown.text,
         };
 
         const cancelBtnStyle = {
             padding: "8px 20px", borderRadius: 4,
-            border: "1px solid #d9d9d9", background: "#fff",
+            border: `1px solid ${theme.dropdown.border}`,
+            background: "transparent",
+            color: theme.dropdown.text,
             cursor: "pointer", fontSize: 14,
         };
 
-        const submitBtnStyle = {
-            padding: "8px 20px", borderRadius: 4,
-            border: "none", background: "#1677ff",
-            color: "#fff", cursor: "pointer", fontSize: 14,
-        };
-
-        const req = <span style={{ color: "#ff4d4f" }}>*</span>;
-
         return (
-            <div style={backdropStyle} onClick={onClose}>
+            <div
+                style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.55)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}
+                onClick={onClose}
+            >
                 <div style={cardStyle} onClick={(e) => e.stopPropagation()}>
-                    <h3 style={{ marginTop: 0, marginBottom: 20, fontSize: 16 }}>{title}</h3>
+                    <h3 style={{ marginTop: 0, marginBottom: 20, fontSize: 16, color: theme.dropdown.text }}>
+                        {isEdit ? "Chỉnh sửa sản phẩm" : "Thêm sản phẩm mới"}
+                    </h3>
 
-                    {/* Tên sản phẩm */}
-                    <div style={fieldStyle}>
-                        <label style={labelStyle}>Tên sản phẩm {req}</label>
+                    <div style={{ marginBottom: 16 }}>
+                        <label style={labelStyle}>Tên sản phẩm <span style={{ color: "#ff4d4f" }}>*</span></label>
                         <input
-                            style={{ ...inputStyle, borderColor: errors.name ? "#ff4d4f" : "#d9d9d9" }}
+                            style={{ ...inputStyle, borderColor: errors.name ? "#ff4d4f" : theme.dropdown.border }}
                             value={name}
                             onChange={(e) => this.handleChange("name", e.target.value)}
                             placeholder="Nhập tên sản phẩm..."
                         />
-                        {errors.name && <div style={errorStyle}>{errors.name}</div>}
+                        {errors.name && <div style={{ color: "#ff4d4f", fontSize: 12, marginTop: 4 }}>{errors.name}</div>}
                     </div>
 
-                    {/* Danh mục */}
-                    <div style={fieldStyle}>
-                        <label style={labelStyle}>Danh mục {req}</label>
-                        <select
-                            style={{ ...inputStyle }}
-                            value={category}
-                            onChange={(e) => this.handleChange("category", e.target.value)}
-                        >
-                            {CATEGORIES.map((c) => (
-                                <option key={c} value={c}>{c}</option>
-                            ))}
+                    <div style={{ marginBottom: 16 }}>
+                        <label style={labelStyle}>Danh mục <span style={{ color: "#ff4d4f" }}>*</span></label>
+                        <select style={inputStyle} value={category} onChange={(e) => this.handleChange("category", e.target.value)}>
+                            {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
                         </select>
                     </div>
 
-                    {/* Giá + Tồn kho hàng ngang */}
-                    <div style={{ ...rowStyle, marginBottom: 16 }}>
-                        <div style={halfStyle}>
-                            <label style={labelStyle}>Giá (đ) {req}</label>
+                    <div style={{ display: "flex", gap: 16, marginBottom: 16 }}>
+                        <div style={{ flex: 1 }}>
+                            <label style={labelStyle}>Giá (đ) <span style={{ color: "#ff4d4f" }}>*</span></label>
                             <input
-                                style={{ ...inputStyle, borderColor: errors.price ? "#ff4d4f" : "#d9d9d9" }}
-                                type="number"
-                                min="0"
-                                value={price}
+                                style={{ ...inputStyle, borderColor: errors.price ? "#ff4d4f" : theme.dropdown.border }}
+                                type="number" min="0" value={price}
                                 onChange={(e) => this.handleChange("price", e.target.value)}
                                 placeholder="VD: 199000"
                             />
-                            {errors.price && <div style={errorStyle}>{errors.price}</div>}
+                            {errors.price && <div style={{ color: "#ff4d4f", fontSize: 12, marginTop: 4 }}>{errors.price}</div>}
                         </div>
-                        <div style={halfStyle}>
-                            <label style={labelStyle}>Tồn kho {req}</label>
+                        <div style={{ flex: 1 }}>
+                            <label style={labelStyle}>Tồn kho <span style={{ color: "#ff4d4f" }}>*</span></label>
                             <input
-                                style={{ ...inputStyle, borderColor: errors.stock ? "#ff4d4f" : "#d9d9d9" }}
-                                type="number"
-                                min="0"
-                                value={stock}
+                                style={{ ...inputStyle, borderColor: errors.stock ? "#ff4d4f" : theme.dropdown.border }}
+                                type="number" min="0" value={stock}
                                 onChange={(e) => this.handleChange("stock", e.target.value)}
                                 placeholder="VD: 100"
                             />
-                            {errors.stock && <div style={errorStyle}>{errors.stock}</div>}
+                            {errors.stock && <div style={{ color: "#ff4d4f", fontSize: 12, marginTop: 4 }}>{errors.stock}</div>}
                         </div>
                     </div>
 
-                    {/* Mô tả */}
-                    <div style={fieldStyle}>
+                    <div style={{ marginBottom: 16 }}>
                         <label style={labelStyle}>Mô tả</label>
                         <textarea
                             style={{ ...inputStyle, resize: "vertical" }}
-                            rows={3}
-                            value={description}
+                            rows={3} value={description}
                             onChange={(e) => this.handleChange("description", e.target.value)}
                             placeholder="Mô tả ngắn về sản phẩm..."
                         />
                     </div>
 
-                    {/* Trạng thái */}
-                    <div style={{ ...fieldStyle, display: "flex", alignItems: "center", gap: 10 }}>
+                    <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 10 }}>
                         <input
-                            type="checkbox"
-                            id="product-active"
-                            checked={active}
+                            type="checkbox" id="product-active" checked={active}
                             onChange={(e) => this.handleChange("active", e.target.checked)}
                             style={{ width: 16, height: 16, cursor: "pointer" }}
                         />
-                        <label htmlFor="product-active" style={{ ...labelStyle, margin: 0, cursor: "pointer" }}>
-                            Đang bán
-                        </label>
+                        <label htmlFor="product-active" style={{ ...labelStyle, margin: 0, cursor: "pointer" }}>Đang bán</label>
                     </div>
 
-                    <div style={footerStyle}>
+                    <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, marginTop: 24, paddingTop: 16, borderTop: `1px solid ${theme.dropdown.border}` }}>
                         <button style={cancelBtnStyle} onClick={onClose}>Huỷ</button>
-                        <button style={submitBtnStyle} onClick={this.handleSubmit}>Lưu</button>
+                        <button style={{ padding: "8px 20px", borderRadius: 4, border: "none", background: "#1677ff", color: "#fff", cursor: "pointer", fontSize: 14 }} onClick={this.handleSubmit}>Lưu</button>
                     </div>
                 </div>
             </div>

--- a/src/pages/ToolsPage/ToolTable.jsx
+++ b/src/pages/ToolsPage/ToolTable.jsx
@@ -1,17 +1,21 @@
 import React, { Component } from "react";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
 
 function formatPrice(price) {
     return price.toLocaleString("vi-VN") + "đ";
 }
 
 class ToolTable extends Component {
+    static contextType = ThemeContext;
+
     render() {
         const { tools, onEdit, onDelete, onToggleActive } = this.props;
+        const { theme } = this.context;
 
         const tableStyle = {
             width: "100%",
             borderCollapse: "collapse",
-            background: "#fff",
+            background: theme.dropdown.bg,
             borderRadius: 8,
             overflow: "hidden",
             boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
@@ -23,16 +27,16 @@ class ToolTable extends Component {
             textAlign: "left",
             fontWeight: 600,
             fontSize: 13,
-            color: "#555",
-            background: "#fafafa",
-            borderBottom: "1px solid #f0f0f0",
+            color: theme.dropdown.textSub,
+            background: theme.toggleIcon === "🌙" ? "rgba(255,255,255,0.04)" : "#fafafa",
+            borderBottom: `1px solid ${theme.dropdown.border}`,
             whiteSpace: "nowrap",
         };
 
         const tdStyle = {
             padding: "12px 16px",
-            borderBottom: "1px solid #f5f5f5",
-            color: "#333",
+            borderBottom: `1px solid ${theme.dropdown.border}`,
+            color: theme.dropdown.text,
             verticalAlign: "middle",
         };
 
@@ -53,7 +57,7 @@ class ToolTable extends Component {
             padding: "2px 8px",
             borderRadius: 4,
             fontSize: 12,
-            background: "#f0f5ff",
+            background: theme.toggleIcon === "🌙" ? "rgba(47,84,235,0.15)" : "#f0f5ff",
             color: "#2f54eb",
             border: "1px solid #adc6ff",
         };
@@ -76,7 +80,7 @@ class ToolTable extends Component {
                     <tbody>
                         {tools.length === 0 ? (
                             <tr>
-                                <td colSpan={8} style={{ ...tdStyle, textAlign: "center", color: "#aaa", padding: 32 }}>
+                                <td colSpan={8} style={{ ...tdStyle, textAlign: "center", color: theme.dropdown.textSub, padding: 32 }}>
                                     Chưa có sản phẩm nào
                                 </td>
                             </tr>
@@ -101,14 +105,14 @@ class ToolTable extends Component {
 
                                 const stockStyle = {
                                     fontWeight: 600,
-                                    color: product.stock === 0 ? "#ff4d4f" : product.stock < 10 ? "#fa8c16" : "#333",
+                                    color: product.stock === 0 ? "#ff4d4f" : product.stock < 10 ? "#fa8c16" : theme.dropdown.text,
                                 };
 
                                 const createdDate = new Date(product.createdAt).toLocaleDateString("vi-VN");
 
                                 return (
                                     <tr key={product.id}>
-                                        <td style={{ ...tdStyle, color: "#999", width: 48 }}>{index + 1}</td>
+                                        <td style={{ ...tdStyle, color: theme.dropdown.textSub, width: 48 }}>{index + 1}</td>
                                         <td style={{ ...tdStyle, fontWeight: 500, maxWidth: 220 }}>{product.name}</td>
                                         <td style={tdStyle}>
                                             <span style={categoryBadgeStyle}>{product.category}</span>
@@ -120,23 +124,17 @@ class ToolTable extends Component {
                                             <span style={stockStyle}>{product.stock}</span>
                                         </td>
                                         <td style={tdStyle}>
-                                            <span style={badgeStyle}>
-                                                {product.active ? "Đang bán" : "Ngừng bán"}
-                                            </span>
+                                            <span style={badgeStyle}>{product.active ? "Đang bán" : "Ngừng bán"}</span>
                                         </td>
-                                        <td style={{ ...tdStyle, whiteSpace: "nowrap", color: "#888" }}>
+                                        <td style={{ ...tdStyle, whiteSpace: "nowrap", color: theme.dropdown.textSub }}>
                                             {createdDate}
                                         </td>
                                         <td style={{ ...tdStyle, whiteSpace: "nowrap" }}>
-                                            <button style={editBtn} onClick={() => onEdit(product)}>
-                                                Sửa
-                                            </button>
+                                            <button style={editBtn} onClick={() => onEdit(product)}>Sửa</button>
                                             <button style={toggleBtn} onClick={() => onToggleActive(product.id)}>
                                                 {product.active ? "Ẩn" : "Bán"}
                                             </button>
-                                            <button style={deleteBtn} onClick={() => onDelete(product.id)}>
-                                                Xoá
-                                            </button>
+                                            <button style={deleteBtn} onClick={() => onDelete(product.id)}>Xoá</button>
                                         </td>
                                     </tr>
                                 );

--- a/src/pages/ToolsPage/ToolsPage.jsx
+++ b/src/pages/ToolsPage/ToolsPage.jsx
@@ -3,15 +3,18 @@ import { MOCK_TOOLS } from "../../data/mockTools.js";
 import ToolTable from "./ToolTable.jsx";
 import ToolFormModal from "./ToolFormModal.jsx";
 import ToolDeleteDialog from "./ToolDeleteDialog.jsx";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
 
 class ToolsPage extends Component {
+    static contextType = ThemeContext;
+
     constructor(props) {
         super(props);
         this.state = {
             tools: [],
             loading: false,
             modalOpen: false,
-            modalMode: "create", // "create" | "edit"
+            modalMode: "create",
             editingTool: null,
             deleteDialogOpen: false,
             deletingToolId: null,
@@ -20,7 +23,6 @@ class ToolsPage extends Component {
     }
 
     componentDidMount() {
-        // TODO: thay bằng axiosClient.get("/admin/ai-tools") khi có API thật
         this.setState({ tools: [...MOCK_TOOLS] });
     }
 
@@ -40,18 +42,10 @@ class ToolsPage extends Component {
         const { modalMode, editingTool, tools } = this.state;
 
         if (modalMode === "create") {
-            // TODO: thay bằng axiosClient.post("/admin/ai-tools", formData)
-            const newTool = {
-                ...formData,
-                id: Date.now(),
-                createdAt: new Date().toISOString(),
-            };
+            const newTool = { ...formData, id: Date.now(), createdAt: new Date().toISOString() };
             this.setState({ tools: [...tools, newTool], modalOpen: false });
         } else {
-            // TODO: thay bằng axiosClient.put(`/admin/ai-tools/${editingTool.id}`, formData)
-            const updated = tools.map((t) =>
-                t.id === editingTool.id ? { ...t, ...formData } : t
-            );
+            const updated = tools.map((t) => t.id === editingTool.id ? { ...t, ...formData } : t);
             this.setState({ tools: updated, modalOpen: false, editingTool: null });
         }
     };
@@ -62,7 +56,6 @@ class ToolsPage extends Component {
 
     handleDeleteConfirm = () => {
         const { tools, deletingToolId } = this.state;
-        // TODO: thay bằng axiosClient.delete(`/admin/ai-tools/${deletingToolId}`)
         const updated = tools.filter((t) => t.id !== deletingToolId);
         this.setState({ tools: updated, deleteDialogOpen: false, deletingToolId: null });
     };
@@ -73,39 +66,22 @@ class ToolsPage extends Component {
 
     handleToggleActive = (id) => {
         const { tools } = this.state;
-        // TODO: thay bằng axiosClient.patch(`/admin/ai-tools/${id}/toggle`)
-        const updated = tools.map((t) =>
-            t.id === id ? { ...t, active: !t.active } : t
-        );
+        const updated = tools.map((t) => t.id === id ? { ...t, active: !t.active } : t);
         this.setState({ tools: updated });
     };
 
     render() {
         const { tools, modalOpen, modalMode, editingTool, deleteDialogOpen } = this.state;
-
-        const headerStyle = {
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: 24,
-        };
-
-        const createBtnStyle = {
-            padding: "8px 18px",
-            borderRadius: 4,
-            border: "none",
-            background: "#1677ff",
-            color: "#fff",
-            cursor: "pointer",
-            fontSize: 14,
-            fontWeight: 500,
-        };
+        const { theme } = this.context;
 
         return (
             <div>
-                <div style={headerStyle}>
-                    <h2 style={{ margin: 0 }}>Quản lý Sản phẩm</h2>
-                    <button style={createBtnStyle} onClick={this.handleCreate}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+                    <h2 style={{ margin: 0, color: theme.main.text }}>Quản lý Sản phẩm</h2>
+                    <button
+                        style={{ padding: "8px 18px", borderRadius: 4, border: "none", background: "#1677ff", color: "#fff", cursor: "pointer", fontSize: 14, fontWeight: 500 }}
+                        onClick={this.handleCreate}
+                    >
                         + Thêm sản phẩm
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- Apply `ThemeContext` vào `ToolsPage`, `ToolTable`, `ToolFormModal`, `ToolDeleteDialog`
- Table background, header, cell text, modal card, inputs, buttons đều theo theme dark/light
- Closes #10

## Test plan
- [ ] Toggle sang dark mode → ToolsPage hiển thị đúng màu dark
- [ ] Mở modal Thêm/Sửa sản phẩm → background và input theo theme
- [ ] Mở dialog Xoá → background theo theme