### PR TITLE
fix: update infra-devops-agent to reflect GitOps deployment workflow

### DIFF
--- a/.claude/agents/infra-devops-agent.md
+++ b/.claude/agents/infra-devops-agent.md
@@ -19,11 +19,21 @@ You are an infrastructure and DevOps specialist for the DevAPIHub platform. Your
 
 - **Docker**: Multi-stage builds, published to Docker Hub (`trivip002/admin-ui:latest`)
 - **Nginx**: Serves the SPA, must have `try_files` for client-side routing
-- **Makefile**: Primary deployment interface
-  - `make release` — install → build → deploy → nginx-restart on remote
-  - `make deploy` — SCP `dist/` to remote server
 - **Kubernetes (EKS)**: Production workloads chạy trên Amazon EKS
-- **ArgoCD**: GitOps deployment — K8s manifests quản lý tại `https://github.com/devapihub/argocd/tree/main/app/admin-ui/k8s`
+- **ArgoCD (GitOps)**: Deployment được trigger bằng cách commit thay đổi image tag vào ArgoCD repo
+  - ArgoCD repo: `devapihub/argocd` tại `app/admin-ui/k8s`
+  - ArgoCD tự động sync và deploy lên EKS khi manifest thay đổi
+
+## Deployment Workflow (Production)
+
+1. Build và push Docker image lên Docker Hub:
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 -t trivip002/admin-ui:<tag> --push .
+   ```
+2. Cập nhật image tag trong K8s manifest tại repo `devapihub/argocd/app/admin-ui/k8s`
+3. Commit và push lên ArgoCD repo → ArgoCD tự sync lên EKS
+
+**Không dùng Makefile hay SCP** cho production deployment.
 
 ## Build & Dev Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,10 @@ Agent(
 Agent(
   subagent_type: "general-purpose",
   prompt: "Bạn là infra-devops-agent — Infrastructure & DevOps specialist cho devapihub/admin-ui.
-  Stack: Docker (trivip002/admin-ui:latest), Nginx, EKS, ArgoCD.
-  Remote server: 61.14.234.12:2018 | Deploy path: /var/www/hughhuynh97.com/dist
-  ArgoCD repo: devapihub/argocd tại app/admin-ui/k8s
-  Luôn confirm trước khi chạy lệnh trên remote server.
+  Stack: Docker (trivip002/admin-ui:latest), Nginx, EKS, ArgoCD (GitOps).
+  Deployment workflow: build image → push Docker Hub → update image tag trong devapihub/argocd/app/admin-ui/k8s → commit/push → ArgoCD sync lên EKS.
+  Không dùng Makefile hay SCP cho production.
+  Luôn confirm trước khi chạy lệnh ảnh hưởng production.
 
   Task: <mô tả task cụ thể>"
 )


### PR DESCRIPTION
## Summary

- Remove Makefile/SCP references from `infra-devops-agent` deployment stack
- Add explicit GitOps production workflow: build image → push Docker Hub → update image tag in `devapihub/argocd/app/admin-ui/k8s` → ArgoCD sync to EKS
- Update `CLAUDE.md` infra-devops-agent invocation context to match the new workflow

Closes #21

## Test plan

- [ ] Verify `.claude/agents/infra-devops-agent.md` no longer mentions Makefile or SCP for production deployment
- [ ] Verify the Deployment Workflow (Production) section is present and accurate
- [ ] Verify `CLAUDE.md` infra-devops-agent prompt snippet reflects GitOps workflow
- [ ] Confirm no functional code changes — docs/agent-config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)