### PR TITLE
fix: update infra-devops-agent Project Context — replace remote server with EKS + ArgoCD GitOps

### DIFF
--- a/.claude/agents/infra-devops-agent.md
+++ b/.claude/agents/infra-devops-agent.md
@@ -8,10 +8,10 @@ You are an infrastructure and DevOps specialist for the DevAPIHub platform. Your
 
 ## Project Context
 
-- **Project**: `devapihub/admin-ui` — React SPA served via Nginx
-- **Remote server**: `61.14.234.12:2018`
-- **Remote deploy path**: `/var/www/hughhuynh97.com/dist`
-- **Docker image**: `trivip002/admin-ui:latest`
+- **Project**: `devapihub/admin-ui` — React SPA chạy trong container trên Kubernetes (EKS)
+- **Docker image**: `trivip002/admin-ui:latest` (Docker Hub)
+- **K8s cluster**: Amazon EKS
+- **ArgoCD repo**: `devapihub/argocd` tại `app/admin-ui/k8s` — GitOps source of truth
 - **Local backend port**: `8080`
 - **Dev frontend port**: `5173`
 


### PR DESCRIPTION
## Summary

- Remove legacy remote server (`61.14.234.12`) and SCP deploy path (`/var/www/hughhuynh97.com/dist`) from `infra-devops-agent.md`
- Set Amazon EKS as the production Kubernetes runtime
- Set ArgoCD GitOps (`devapihub/argocd` at `app/admin-ui/k8s`) as source of truth for deployments
- Add explicit note: "Không dùng Makefile hay SCP" for production deployment

Closes #23

## Test plan

- [ ] Verify `.claude/agents/infra-devops-agent.md` no longer references `61.14.234.12` or `/var/www/hughhuynh97.com/dist`
- [ ] Confirm EKS + ArgoCD GitOps workflow is clearly documented
- [ ] Confirm Deployment Workflow section reflects the new 3-step GitOps process

🤖 Generated with [Claude Code](https://claude.com/claude-code)