### PR TITLE
feat: add Role & Permission management page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import HomePage from "./pages/HomePage/HomePage.jsx";
 import ToolsPage from "./pages/ToolsPage/ToolsPage.jsx";
 import UsersPage from "./pages/UsersPage/UsersPage.jsx";
 import NotificationsPage from "./pages/NotificationsPage/NotificationsPage.jsx";
+import RolePermissionPage from "./pages/RolePermissionPage/RolePermissionPage.jsx";
 import DashboardLayout from "./components/layout/DashboardLayout.jsx";
 import ThemeProvider from "./context/ThemeContext.jsx";
 import "./App.css";
@@ -103,6 +104,20 @@ class App extends Component {
                             isLoggedIn ? (
                                 <DashboardLayout username={username} onLogout={this.handleLogout}>
                                     <NotificationsPage />
+                                </DashboardLayout>
+                            ) : (
+                                <Navigate to="/login" replace />
+                            )
+                        }
+                    />
+
+                    {/* Phân quyền */}
+                    <Route
+                        path="/roles"
+                        element={
+                            isLoggedIn ? (
+                                <DashboardLayout username={username} onLogout={this.handleLogout}>
+                                    <RolePermissionPage />
                                 </DashboardLayout>
                             ) : (
                                 <Navigate to="/login" replace />

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
     { label: "Trang chủ", path: "/", icon: "🏠" },
     { label: "Ecommerce", path: "/tools", icon: "🛒" },
     { label: "Quản lý User", path: "/users", icon: "👥" },
+    { label: "Phân quyền", path: "/roles", icon: "🔐" },
 ];
 
 class Sidebar extends Component {

--- a/src/pages/RolePermissionPage/RoleDeleteDialog.jsx
+++ b/src/pages/RolePermissionPage/RoleDeleteDialog.jsx
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
+
+class RoleDeleteDialog extends Component {
+    static contextType = ThemeContext;
+
+    render() {
+        const { open, roleName, onConfirm, onCancel } = this.props;
+        const { theme } = this.context;
+
+        if (!open) return null;
+
+        const cancelBtnStyle = {
+            padding: "8px 20px",
+            borderRadius: 4,
+            border: `1px solid ${theme.dropdown.border}`,
+            background: "transparent",
+            color: theme.dropdown.text,
+            cursor: "pointer",
+            fontSize: 14,
+        };
+
+        return (
+            <div
+                style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.55)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}
+                onClick={onCancel}
+            >
+                <div
+                    style={{ background: theme.dropdown.bg, borderRadius: 8, padding: "28px 32px", width: 400, boxShadow: "0 4px 24px rgba(0,0,0,0.3)", border: `1px solid ${theme.dropdown.border}` }}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <h3 style={{ marginTop: 0, fontSize: 16, color: theme.dropdown.text }}>Xác nhận xoá</h3>
+                    <p style={{ color: theme.dropdown.textSub, fontSize: 14, lineHeight: 1.6 }}>
+                        Bạn có chắc muốn xoá role <strong style={{ color: theme.dropdown.text }}>{roleName}</strong> không?
+                        <br />
+                        <span style={{ color: "#ff4d4f", fontSize: 13 }}>Hành động này không thể hoàn tác.</span>
+                    </p>
+                    <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, marginTop: 24 }}>
+                        <button style={cancelBtnStyle} onClick={onCancel}>Huỷ</button>
+                        <button style={{ padding: "8px 20px", borderRadius: 4, border: "none", background: "#ff4d4f", color: "#fff", cursor: "pointer", fontSize: 14 }} onClick={onConfirm}>Xoá</button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default RoleDeleteDialog;

--- a/src/pages/RolePermissionPage/RoleFormModal.jsx
+++ b/src/pages/RolePermissionPage/RoleFormModal.jsx
@@ -1,0 +1,210 @@
+import React, { Component } from "react";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
+import { ALL_PERMISSIONS } from "./mockRoles.js";
+
+const EMPTY_FORM = { name: "", description: "", permissions: [] };
+
+class RoleFormModal extends Component {
+    static contextType = ThemeContext;
+
+    constructor(props) {
+        super(props);
+        this.state = { ...EMPTY_FORM, errors: {} };
+    }
+
+    componentDidUpdate(prevProps) {
+        if (!prevProps.open && this.props.open) {
+            const { initialData } = this.props;
+            if (initialData) {
+                this.setState({
+                    name: initialData.name || "",
+                    description: initialData.description || "",
+                    permissions: [...(initialData.permissions || [])],
+                    errors: {},
+                });
+            } else {
+                this.setState({ ...EMPTY_FORM, errors: {} });
+            }
+        }
+    }
+
+    handleChange = (field, value) => {
+        this.setState((prev) => ({
+            [field]: value,
+            errors: { ...prev.errors, [field]: "" },
+        }));
+    };
+
+    handlePermissionToggle = (key) => {
+        this.setState((prev) => {
+            const has = prev.permissions.includes(key);
+            return {
+                permissions: has ? prev.permissions.filter((p) => p !== key) : [...prev.permissions, key],
+                errors: { ...prev.errors, permissions: "" },
+            };
+        });
+    };
+
+    handleSelectAll = () => {
+        const allKeys = ALL_PERMISSIONS.map((p) => p.key);
+        this.setState((prev) => ({
+            permissions: prev.permissions.length === allKeys.length ? [] : allKeys,
+        }));
+    };
+
+    handleSubmit = () => {
+        const { name, description, permissions } = this.state;
+        const errors = {};
+        if (!name.trim()) errors.name = "Vui lòng nhập tên role";
+        if (permissions.length === 0) errors.permissions = "Vui lòng chọn ít nhất 1 permission";
+        if (Object.keys(errors).length > 0) {
+            this.setState({ errors });
+            return;
+        }
+        this.props.onSubmit({ name: name.trim(), description: description.trim(), permissions });
+    };
+
+    render() {
+        const { open, mode, onClose } = this.props;
+        const { name, description, permissions, errors } = this.state;
+        const { theme } = this.context;
+
+        if (!open) return null;
+
+        const isDark = theme.toggleIcon === "🌙";
+        const isEdit = mode === "edit";
+        const allKeys = ALL_PERMISSIONS.map((p) => p.key);
+        const isAllSelected = permissions.length === allKeys.length;
+
+        const cardStyle = {
+            background: theme.dropdown.bg,
+            borderRadius: 8,
+            padding: "28px 32px",
+            minWidth: 520,
+            maxWidth: 620,
+            width: "100%",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.3)",
+            maxHeight: "90vh",
+            overflowY: "auto",
+        };
+
+        const labelStyle = {
+            display: "block",
+            marginBottom: 6,
+            fontWeight: 500,
+            fontSize: 13,
+            color: theme.dropdown.text,
+        };
+
+        const inputStyle = {
+            width: "100%",
+            padding: "8px 12px",
+            border: `1px solid ${theme.dropdown.border}`,
+            borderRadius: 4,
+            fontSize: 14,
+            boxSizing: "border-box",
+            outline: "none",
+            background: isDark ? "rgba(255,255,255,0.06)" : "#fff",
+            color: theme.dropdown.text,
+        };
+
+        const cancelBtnStyle = {
+            padding: "8px 20px",
+            borderRadius: 4,
+            border: `1px solid ${theme.dropdown.border}`,
+            background: "transparent",
+            color: theme.dropdown.text,
+            cursor: "pointer",
+            fontSize: 14,
+        };
+
+        return (
+            <div
+                style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.55)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}
+                onClick={onClose}
+            >
+                <div style={cardStyle} onClick={(e) => e.stopPropagation()}>
+                    <h3 style={{ marginTop: 0, marginBottom: 20, fontSize: 16, color: theme.dropdown.text }}>
+                        {isEdit ? "Chỉnh sửa Role" : "Thêm Role mới"}
+                    </h3>
+
+                    <div style={{ marginBottom: 16 }}>
+                        <label style={labelStyle}>Tên Role <span style={{ color: "#ff4d4f" }}>*</span></label>
+                        <input
+                            style={{ ...inputStyle, borderColor: errors.name ? "#ff4d4f" : theme.dropdown.border }}
+                            value={name}
+                            onChange={(e) => this.handleChange("name", e.target.value)}
+                            placeholder="VD: Admin, Editor, Viewer..."
+                        />
+                        {errors.name && <div style={{ color: "#ff4d4f", fontSize: 12, marginTop: 4 }}>{errors.name}</div>}
+                    </div>
+
+                    <div style={{ marginBottom: 16 }}>
+                        <label style={labelStyle}>Mô tả</label>
+                        <textarea
+                            style={{ ...inputStyle, resize: "vertical" }}
+                            rows={2}
+                            value={description}
+                            onChange={(e) => this.handleChange("description", e.target.value)}
+                            placeholder="Mô tả ngắn về role này..."
+                        />
+                    </div>
+
+                    <div style={{ marginBottom: 16 }}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+                            <label style={{ ...labelStyle, margin: 0 }}>
+                                Permissions <span style={{ color: "#ff4d4f" }}>*</span>
+                            </label>
+                            <button
+                                style={{ fontSize: 12, padding: "3px 10px", borderRadius: 4, border: `1px solid ${theme.dropdown.border}`, background: "transparent", color: theme.dropdown.textSub, cursor: "pointer" }}
+                                onClick={this.handleSelectAll}
+                            >
+                                {isAllSelected ? "Bỏ chọn tất cả" : "Chọn tất cả"}
+                            </button>
+                        </div>
+                        <div style={{
+                            display: "grid",
+                            gridTemplateColumns: "1fr 1fr",
+                            gap: 8,
+                            padding: 12,
+                            border: `1px solid ${errors.permissions ? "#ff4d4f" : theme.dropdown.border}`,
+                            borderRadius: 6,
+                            background: isDark ? "rgba(255,255,255,0.02)" : "#fafafa",
+                        }}>
+                            {ALL_PERMISSIONS.map((perm) => {
+                                const checked = permissions.includes(perm.key);
+                                return (
+                                    <label
+                                        key={perm.key}
+                                        style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", fontSize: 13, color: theme.dropdown.text, userSelect: "none" }}
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={checked}
+                                            onChange={() => this.handlePermissionToggle(perm.key)}
+                                            style={{ width: 14, height: 14, cursor: "pointer", accentColor: "#1677ff" }}
+                                        />
+                                        {perm.label}
+                                    </label>
+                                );
+                            })}
+                        </div>
+                        {errors.permissions && <div style={{ color: "#ff4d4f", fontSize: 12, marginTop: 4 }}>{errors.permissions}</div>}
+                    </div>
+
+                    <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, marginTop: 24, paddingTop: 16, borderTop: `1px solid ${theme.dropdown.border}` }}>
+                        <button style={cancelBtnStyle} onClick={onClose}>Huỷ</button>
+                        <button
+                            style={{ padding: "8px 20px", borderRadius: 4, border: "none", background: "#1677ff", color: "#fff", cursor: "pointer", fontSize: 14 }}
+                            onClick={this.handleSubmit}
+                        >
+                            Lưu
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default RoleFormModal;

--- a/src/pages/RolePermissionPage/RolePermissionPage.jsx
+++ b/src/pages/RolePermissionPage/RolePermissionPage.jsx
@@ -1,0 +1,108 @@
+import React, { Component } from "react";
+import { MOCK_ROLES } from "./mockRoles.js";
+import RoleTable from "./RoleTable.jsx";
+import RoleFormModal from "./RoleFormModal.jsx";
+import RoleDeleteDialog from "./RoleDeleteDialog.jsx";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
+
+class RolePermissionPage extends Component {
+    static contextType = ThemeContext;
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            roles: [],
+            modalOpen: false,
+            modalMode: "create",
+            editingRole: null,
+            deleteDialogOpen: false,
+            deletingRole: null,
+        };
+    }
+
+    componentDidMount() {
+        this.setState({ roles: [...MOCK_ROLES] });
+    }
+
+    handleCreate = () => {
+        this.setState({ modalOpen: true, modalMode: "create", editingRole: null });
+    };
+
+    handleEdit = (role) => {
+        this.setState({ modalOpen: true, modalMode: "edit", editingRole: role });
+    };
+
+    handleModalClose = () => {
+        this.setState({ modalOpen: false, editingRole: null });
+    };
+
+    handleFormSubmit = (formData) => {
+        const { modalMode, editingRole, roles } = this.state;
+        if (modalMode === "create") {
+            const newRole = { ...formData, id: Date.now(), createdAt: new Date().toISOString() };
+            this.setState({ roles: [...roles, newRole], modalOpen: false });
+        } else {
+            const updated = roles.map((r) => r.id === editingRole.id ? { ...r, ...formData } : r);
+            this.setState({ roles: updated, modalOpen: false, editingRole: null });
+        }
+    };
+
+    handleDeleteRequest = (role) => {
+        this.setState({ deleteDialogOpen: true, deletingRole: role });
+    };
+
+    handleDeleteConfirm = () => {
+        const { roles, deletingRole } = this.state;
+        this.setState({
+            roles: roles.filter((r) => r.id !== deletingRole.id),
+            deleteDialogOpen: false,
+            deletingRole: null,
+        });
+    };
+
+    handleDeleteCancel = () => {
+        this.setState({ deleteDialogOpen: false, deletingRole: null });
+    };
+
+    render() {
+        const { roles, modalOpen, modalMode, editingRole, deleteDialogOpen, deletingRole } = this.state;
+        const { theme } = this.context;
+
+        return (
+            <div>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+                    <h2 style={{ margin: 0, color: theme.main.text }}>Phân quyền</h2>
+                    <button
+                        style={{ padding: "8px 18px", borderRadius: 4, border: "none", background: "#1677ff", color: "#fff", cursor: "pointer", fontSize: 14, fontWeight: 500 }}
+                        onClick={this.handleCreate}
+                    >
+                        + Thêm Role
+                    </button>
+                </div>
+
+                <RoleTable
+                    roles={roles}
+                    onEdit={this.handleEdit}
+                    onDelete={this.handleDeleteRequest}
+                />
+
+                <RoleFormModal
+                    open={modalOpen}
+                    mode={modalMode}
+                    initialData={editingRole}
+                    onSubmit={this.handleFormSubmit}
+                    onClose={this.handleModalClose}
+                />
+
+                <RoleDeleteDialog
+                    open={deleteDialogOpen}
+                    roleName={deletingRole ? deletingRole.name : ""}
+                    onConfirm={this.handleDeleteConfirm}
+                    onCancel={this.handleDeleteCancel}
+                />
+            </div>
+        );
+    }
+}
+
+export default RolePermissionPage;

--- a/src/pages/RolePermissionPage/RoleTable.jsx
+++ b/src/pages/RolePermissionPage/RoleTable.jsx
@@ -1,0 +1,135 @@
+import React, { Component } from "react";
+import { ThemeContext } from "../../context/ThemeContext.jsx";
+import { ALL_PERMISSIONS } from "./mockRoles.js";
+
+class RoleTable extends Component {
+    static contextType = ThemeContext;
+
+    render() {
+        const { roles, onEdit, onDelete } = this.props;
+        const { theme } = this.context;
+
+        const isDark = theme.toggleIcon === "🌙";
+
+        const tableStyle = {
+            width: "100%",
+            borderCollapse: "collapse",
+            background: theme.dropdown.bg,
+            borderRadius: 8,
+            overflow: "hidden",
+            boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+            fontSize: 14,
+        };
+
+        const thStyle = {
+            padding: "12px 16px",
+            textAlign: "left",
+            fontWeight: 600,
+            fontSize: 13,
+            color: theme.dropdown.textSub,
+            background: isDark ? "rgba(255,255,255,0.04)" : "#fafafa",
+            borderBottom: `1px solid ${theme.dropdown.border}`,
+            whiteSpace: "nowrap",
+        };
+
+        const tdStyle = {
+            padding: "12px 16px",
+            borderBottom: `1px solid ${theme.dropdown.border}`,
+            color: theme.dropdown.text,
+            verticalAlign: "middle",
+        };
+
+        const btnBase = {
+            padding: "5px 10px",
+            borderRadius: 4,
+            border: "none",
+            cursor: "pointer",
+            fontSize: 12,
+            marginRight: 6,
+        };
+
+        const editBtn = { ...btnBase, background: "#e6f4ff", color: "#1677ff" };
+        const deleteBtn = { ...btnBase, background: "#fff1f0", color: "#ff4d4f" };
+
+        const permLabelMap = ALL_PERMISSIONS.reduce((acc, p) => {
+            acc[p.key] = p.label;
+            return acc;
+        }, {});
+
+        const permColors = [
+            { bg: isDark ? "rgba(22,119,255,0.15)" : "#e6f4ff", color: "#1677ff", border: "#91caff" },
+            { bg: isDark ? "rgba(82,196,26,0.15)" : "#f6ffed", color: "#52c41a", border: "#b7eb8f" },
+            { bg: isDark ? "rgba(250,140,22,0.15)" : "#fff7e6", color: "#fa8c16", border: "#ffd591" },
+            { bg: isDark ? "rgba(114,46,209,0.15)" : "#f9f0ff", color: "#722ed1", border: "#d3adf7" },
+            { bg: isDark ? "rgba(255,77,79,0.15)" : "#fff1f0", color: "#ff4d4f", border: "#ffccc7" },
+        ];
+
+        return (
+            <div style={{ overflowX: "auto" }}>
+                <table style={tableStyle}>
+                    <thead>
+                        <tr>
+                            <th style={thStyle}>STT</th>
+                            <th style={thStyle}>Tên Role</th>
+                            <th style={thStyle}>Mô tả</th>
+                            <th style={thStyle}>Permissions</th>
+                            <th style={thStyle}>Ngày tạo</th>
+                            <th style={thStyle}>Thao tác</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {roles.length === 0 ? (
+                            <tr>
+                                <td colSpan={6} style={{ ...tdStyle, textAlign: "center", color: theme.dropdown.textSub, padding: 32 }}>
+                                    Chưa có role nào
+                                </td>
+                            </tr>
+                        ) : (
+                            roles.map((role, index) => (
+                                <tr key={role.id}>
+                                    <td style={{ ...tdStyle, color: theme.dropdown.textSub, width: 48 }}>{index + 1}</td>
+                                    <td style={{ ...tdStyle, fontWeight: 600, whiteSpace: "nowrap" }}>{role.name}</td>
+                                    <td style={{ ...tdStyle, color: theme.dropdown.textSub, maxWidth: 200 }}>{role.description}</td>
+                                    <td style={{ ...tdStyle, maxWidth: 400 }}>
+                                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                                            {role.permissions.map((pKey, i) => {
+                                                const c = permColors[i % permColors.length];
+                                                return (
+                                                    <span
+                                                        key={pKey}
+                                                        style={{
+                                                            display: "inline-block",
+                                                            padding: "2px 8px",
+                                                            borderRadius: 4,
+                                                            fontSize: 11,
+                                                            fontWeight: 500,
+                                                            background: c.bg,
+                                                            color: c.color,
+                                                            border: `1px solid ${c.border}`,
+                                                            whiteSpace: "nowrap",
+                                                        }}
+                                                    >
+                                                        {permLabelMap[pKey] || pKey}
+                                                    </span>
+                                                );
+                                            })}
+                                        </div>
+                                    </td>
+                                    <td style={{ ...tdStyle, whiteSpace: "nowrap", color: theme.dropdown.textSub }}>
+                                        {new Date(role.createdAt).toLocaleDateString("vi-VN")}
+                                    </td>
+                                    <td style={{ ...tdStyle, whiteSpace: "nowrap" }}>
+                                        <button style={editBtn} onClick={() => onEdit(role)}>Sửa</button>
+                                        <button style={deleteBtn} onClick={() => onDelete(role)}>Xoá</button>
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        );
+    }
+}
+
+export default RoleTable;

--- a/src/pages/RolePermissionPage/mockRoles.js
+++ b/src/pages/RolePermissionPage/mockRoles.js
@@ -1,0 +1,36 @@
+export const ALL_PERMISSIONS = [
+    { key: "VIEW_USERS", label: "Xem người dùng" },
+    { key: "EDIT_USERS", label: "Sửa người dùng" },
+    { key: "DELETE_USERS", label: "Xoá người dùng" },
+    { key: "VIEW_TOOLS", label: "Xem sản phẩm" },
+    { key: "EDIT_TOOLS", label: "Sửa sản phẩm" },
+    { key: "DELETE_TOOLS", label: "Xoá sản phẩm" },
+    { key: "VIEW_ROLES", label: "Xem phân quyền" },
+    { key: "EDIT_ROLES", label: "Sửa phân quyền" },
+    { key: "DELETE_ROLES", label: "Xoá phân quyền" },
+    { key: "MANAGE_SETTINGS", label: "Quản lý cài đặt" },
+];
+
+export const MOCK_ROLES = [
+    {
+        id: 1,
+        name: "Admin",
+        description: "Toàn quyền quản trị hệ thống",
+        permissions: ALL_PERMISSIONS.map((p) => p.key),
+        createdAt: "2024-01-01T00:00:00.000Z",
+    },
+    {
+        id: 2,
+        name: "Editor",
+        description: "Có thể xem và chỉnh sửa nội dung",
+        permissions: ["VIEW_USERS", "VIEW_TOOLS", "EDIT_TOOLS"],
+        createdAt: "2024-03-15T00:00:00.000Z",
+    },
+    {
+        id: 3,
+        name: "Viewer",
+        description: "Chỉ xem, không chỉnh sửa",
+        permissions: ["VIEW_USERS", "VIEW_TOOLS", "VIEW_ROLES"],
+        createdAt: "2024-06-20T00:00:00.000Z",
+    },
+];


### PR DESCRIPTION
## Summary

- Add `RolePermissionPage` with full CRUD (create, edit, delete) for roles
- Add `RoleTable` displaying roles with permission badges
- Add `RoleFormModal` with checkbox-based permission selection
- Add `RoleDeleteDialog` for delete confirmation
- Add `mockRoles.js` with mock data
- Register `/roles` route in `App.jsx`
- Add "Phân quyền" nav item with 🔐 icon in `Sidebar.jsx`

## Test plan

- [ ] Navigate to `/roles` — page renders correctly
- [ ] Sidebar shows "Phân quyền" link and navigates to `/roles`
- [ ] Role table lists all mock roles with permission badges
- [ ] Click "Tạo mới" — modal opens with empty form and permission checkboxes
- [ ] Fill form and save — new role appears in table
- [ ] Click edit on a role — modal pre-fills with existing data
- [ ] Edit and save — role updates in table
- [ ] Click delete on a role — confirmation dialog appears
- [ ] Confirm delete — role is removed from table

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)