### PR TITLE
fix: nginx proxy_pass https redirect và proxy_ssl_verify off

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,8 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://www.devapihub.com/api/;
+        proxy_pass https://www.devapihub.com/api/;
+        proxy_ssl_verify off;
         proxy_set_header Host www.devapihub.com;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

Fixes #35

- Đổi `proxy_pass` từ `http://` sang `https://` để Nginx kết nối trực tiếp HTTPS với backend, tránh 308 redirect.
- Thêm `proxy_ssl_verify off` để Nginx chấp nhận upstream HTTPS mà không verify certificate.

## Root Cause

`proxy_pass http://` → backend trả về `308 Redirect` → browser follow redirect ra ngoài domain → CORS error.

## Changes

```nginx
- proxy_pass http://www.devapihub.com/api/;
+ proxy_pass https://www.devapihub.com/api/;
+ proxy_ssl_verify off;
```

## Test plan

- [ ] Deploy lên K8s và kiểm tra API calls trong browser không còn CORS error
- [ ] Verify Nginx log không còn upstream redirect
- [ ] Confirm `/api/` requests được proxy đúng tới backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)