### PR TITLE
fix: correct Google OAuth2 authorization URL

### DIFF
--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -98,7 +98,7 @@ class LoginForm extends Component {
                 <Button
                     size="large"
                     block
-                    onClick={() => { window.location.href = "/api/auth/google"; }}
+                    onClick={() => { window.location.href = "/api/oauth2/authorization/google"; }}
                     style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, border: "1px solid #d9d9d9", background: "#fff", color: "#444", fontWeight: 500 }}
                 >
                     <svg width="18" height="18" viewBox="0 0 48 48" style={{ flexShrink: 0 }}>


### PR DESCRIPTION
## Summary

- Fix Google login button URL from `/api/auth/google` to `/api/oauth2/authorization/google`
- Ensures proper Spring Security OAuth2 authorization flow is initiated
- Resolves #39

## Changes

- `src/components/auth/LoginForm.jsx` — corrected `onClick` handler redirect URL

## Test plan

- [ ] Click "Đăng nhập với Google" button on login page
- [ ] Verify browser redirects to Google OAuth2 consent screen (not a 404)
- [ ] Complete Google OAuth2 flow and confirm successful login

🤖 Generated with [Claude Code](https://claude.com/claude-code)